### PR TITLE
Support sqlalchemy1.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,12 +27,12 @@ jobs:
           SQLALCHEMY: ${{ matrix.sql-alchemy }}
           TOXENV: ${{ matrix.toxenv }}
       - name: Upload coverage.xml
-        if: ${{ matrix.sql-alchemy == '1.3' && matrix.python-version == '3.9' }}
+        if: ${{ matrix.sql-alchemy == '1.4' && matrix.python-version == '3.9' }}
         uses: actions/upload-artifact@v2
         with:
           name: graphene-sqlalchemy-coverage
           path: coverage.xml
           if-no-files-found: error
       - name: Upload coverage.xml to codecov
-        if: ${{ matrix.sql-alchemy == '1.3' && matrix.python-version == '3.9' }}
+        if: ${{ matrix.sql-alchemy == '1.4' && matrix.python-version == '3.9' }}
         uses: codecov/codecov-action@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,31 +8,31 @@ jobs:
     strategy:
       max-parallel: 10
       matrix:
-        sql-alchemy: ["1.2", "1.3"]
+        sql-alchemy: ["1.2", "1.3", "1.4"]
         python-version: ["3.6", "3.7", "3.8", "3.9"]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
-    - name: Test with tox
-      run: tox
-      env:
-        SQLALCHEMY: ${{ matrix.sql-alchemy }}
-        TOXENV: ${{ matrix.toxenv }}
-    - name: Upload coverage.xml
-      if: ${{ matrix.sql-alchemy == '1.3' && matrix.python-version == '3.9' }}
-      uses: actions/upload-artifact@v2
-      with:
-        name: graphene-sqlalchemy-coverage
-        path: coverage.xml
-        if-no-files-found: error
-    - name: Upload coverage.xml to codecov
-      if: ${{ matrix.sql-alchemy == '1.3' && matrix.python-version == '3.9' }}
-      uses: codecov/codecov-action@v1
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox tox-gh-actions
+      - name: Test with tox
+        run: tox
+        env:
+          SQLALCHEMY: ${{ matrix.sql-alchemy }}
+          TOXENV: ${{ matrix.toxenv }}
+      - name: Upload coverage.xml
+        if: ${{ matrix.sql-alchemy == '1.3' && matrix.python-version == '3.9' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: graphene-sqlalchemy-coverage
+          path: coverage.xml
+          if-no-files-found: error
+      - name: Upload coverage.xml to codecov
+        if: ${{ matrix.sql-alchemy == '1.3' && matrix.python-version == '3.9' }}
+        uses: codecov/codecov-action@v1

--- a/graphene_sqlalchemy/tests/test_batching.py
+++ b/graphene_sqlalchemy/tests/test_batching.py
@@ -10,7 +10,8 @@ from ..fields import (BatchSQLAlchemyConnectionField,
                       default_connection_field_factory)
 from ..types import ORMField, SQLAlchemyObjectType
 from .models import Article, HairKind, Pet, Reporter
-from .utils import is_sqlalchemy_version_less_than, to_std_dicts
+from ..utils import is_sqlalchemy_version_less_than
+from .utils import to_std_dicts
 
 
 class MockLoggingHandler(logging.Handler):

--- a/graphene_sqlalchemy/tests/test_benchmark.py
+++ b/graphene_sqlalchemy/tests/test_benchmark.py
@@ -4,8 +4,8 @@ import graphene
 from graphene import relay
 
 from ..types import SQLAlchemyObjectType
+from ..utils import is_sqlalchemy_version_less_than
 from .models import Article, HairKind, Pet, Reporter
-from .utils import is_sqlalchemy_version_less_than
 
 if is_sqlalchemy_version_less_than('1.2'):
     pytest.skip('SQL batching only works for SQLAlchemy 1.2+', allow_module_level=True)

--- a/graphene_sqlalchemy/tests/test_converter.py
+++ b/graphene_sqlalchemy/tests/test_converter.py
@@ -48,11 +48,10 @@ def get_field_from_column(column_):
 
 
 def test_should_unknown_sqlalchemy_field_raise_exception():
-    # TODO: SQLALchemy does not export types.Binary, remove or update this test
     re_err = "Don't know how to convert the SQLAlchemy field"
     with pytest.raises(Exception, match=re_err):
         # support legacy Binary type and subsequent LargeBinary
-        get_field(getattr(types, 'LargeBinary', types.Binary)())
+        get_field(getattr(types, 'LargeBinary', types.BINARY)())
 
 
 def test_should_date_convert_string():

--- a/graphene_sqlalchemy/tests/test_converter.py
+++ b/graphene_sqlalchemy/tests/test_converter.py
@@ -47,7 +47,7 @@ def get_field_from_column(column_):
     return convert_sqlalchemy_column(column_prop, get_global_registry(), mock_resolver)
 
 
-def _test_should_unknown_sqlalchemy_field_raise_exception():
+def test_should_unknown_sqlalchemy_field_raise_exception():
     # TODO: SQLALchemy does not export types.Binary, remove or update this test
     re_err = "Don't know how to convert the SQLAlchemy field"
     with pytest.raises(Exception, match=re_err):

--- a/graphene_sqlalchemy/tests/utils.py
+++ b/graphene_sqlalchemy/tests/utils.py
@@ -1,6 +1,3 @@
-import pkg_resources
-
-
 def to_std_dicts(value):
     """Convert nested ordered dicts to normal dicts for better comparison."""
     if isinstance(value, dict):
@@ -9,8 +6,3 @@ def to_std_dicts(value):
         return [to_std_dicts(v) for v in value]
     else:
         return value
-
-
-def is_sqlalchemy_version_less_than(version_string):
-    """Check the installed SQLAlchemy version"""
-    return pkg_resources.get_distribution('SQLAlchemy').parsed_version < pkg_resources.parse_version(version_string)

--- a/graphene_sqlalchemy/tests/utils.py
+++ b/graphene_sqlalchemy/tests/utils.py
@@ -1,3 +1,6 @@
+import re
+
+
 def to_std_dicts(value):
     """Convert nested ordered dicts to normal dicts for better comparison."""
     if isinstance(value, dict):
@@ -6,3 +9,9 @@ def to_std_dicts(value):
         return [to_std_dicts(v) for v in value]
     else:
         return value
+
+
+def remove_cache_miss_stat(message):
+    """Remove the stat from the echoed query message when the cache is missed for sqlalchemy version >= 1.4"""
+    # https://github.com/sqlalchemy/sqlalchemy/blob/990eb3d8813369d3b8a7776ae85fb33627443d30/lib/sqlalchemy/engine/default.py#L1177
+    return re.sub(r"\[generated in \d+.?\d*s\]\s", "", message)

--- a/graphene_sqlalchemy/utils.py
+++ b/graphene_sqlalchemy/utils.py
@@ -1,6 +1,7 @@
 import re
 import warnings
 
+import pkg_resources
 from sqlalchemy.exc import ArgumentError
 from sqlalchemy.orm import class_mapper, object_mapper
 from sqlalchemy.orm.exc import UnmappedClassError, UnmappedInstanceError
@@ -140,3 +141,8 @@ def sort_argument_for_model(cls, has_default=True):
         enum.default = None
 
     return Argument(List(enum), default_value=enum.default)
+
+
+def is_sqlalchemy_version_less_than(version_string):
+    """Check the installed SQLAlchemy version"""
+    return pkg_resources.get_distribution('SQLAlchemy').parsed_version < pkg_resources.parse_version(version_string)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
     # To keep things simple, we only support newer versions of Graphene
     "graphene>=3.0.0b7",
     "promise>=2.3",
-    "SQLAlchemy>=1.1,<1.4",
+    "SQLAlchemy>=1.1,<2",
     "aiodataloader>=0.2.0,<1.0",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pre-commit,py{36,37,38}-sql{11,12,13,14}
+envlist = pre-commit,py{36,37,38,39}-sql{11,12,13,14}
 skipsdist = true
 minversion = 3.7.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ python =
 SQLALCHEMY =
     1.2: sql12
     1.3: sql13
+    1.4: sql14
 
 [testenv]
 passenv = GITHUB_*


### PR DESCRIPTION
This PR builds on the previous work https://github.com/graphql-python/graphene-sqlalchemy/pull/317, supports sqlalchemy 1.4, and passes all test cases for py36, py37, py38, py39 and sqlalchemy1.2,1.3,1.4

- Supports for Batching: 
   - When `sqlalchemy` version is 1.4, use `Query._compile_context` to create the `QueryContext`. 
   - When `sqlalchemy` version is 1.4, use `_load_for_path` with the new signature
   - Change how echoed messages are compared in the batching test cases. When `sqlalchemy` version is 1.4, remove the `[generated in *s] ` from the echoed query message, and compare the sorted values in the `IN` clause instead of comparing all the echoed query. The echoed query from sqlalchemy 1.4 has more descriptive name for Alias and differs from the previous ones. The values generated for the `IN` clause might not be in sorted order.
- `types.Binary` cannot be imported in`test_should_unknown_sqlalchemy_field_raise_exception`
   - Used another type `types.BINARY` to raise the exception in the test. This type is available in all sqlalchemy versions

